### PR TITLE
chore: add the repository link to the Cargo.toml file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "limace"
 description = "Slugify some strings"
 author = ["Jeremie Drouet <jeremie.drouet@gmail.com>"]
+repository = "https://github.com/jdrouet/limace"
 readme = "readme.md"
 license = "MIT"
 version = "0.1.1"


### PR DESCRIPTION
It's best practice to list the repository link.